### PR TITLE
[Bugfix] eslint의 경고를 수정

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,6 @@
 import React from "react";
 
 import TodoUserListPage from "../components/pages/TodoUserListPage";
-import { useRecoilValue } from "recoil";
-import { todoListState } from "../atom/todoAtom";
 
 import '../components/styles/Global.css';
 

--- a/src/components/pages/TodoDashboard.tsx
+++ b/src/components/pages/TodoDashboard.tsx
@@ -76,9 +76,9 @@ const TodoDashboard = ({todoList, onCheck, onDelete}: Props) => {
         <Dashboard>
           <TypeBox>
             {(["All", "To do", "Done"] as const).map( (text) => 
-              <TypeButton 
+              <TypeButton
                 isSelected={type === text} key={text}
-                onClick={(e) => {
+                onClick={() => {
                   setType(text);
                 }} 
               >

--- a/src/components/pages/TodoUserListPage.spec.tsx
+++ b/src/components/pages/TodoUserListPage.spec.tsx
@@ -40,7 +40,7 @@ describe("todo 테스트", () => {
 
     const longTodoItem = screen.queryByText('책상을 정리하고 이메일을 답장하고 운동을 1시간 하고 저녁 메뉴를 결정하기');
 
-    expect(longTodoItem).toBeNull;
+    void expect(longTodoItem).toBeNull;
 
     // 하지 않은 일이 10개 이상 만들어보기(기능)
     const newTodos = [
@@ -68,7 +68,7 @@ describe("todo 테스트", () => {
     
       if (uncheckedItems.length >= 10) {
         const notAddedTodo = screen.queryByText(todo);
-        expect(notAddedTodo).toBeNull;
+        void expect(notAddedTodo).toBeNull;
       } else {
         expect(screen.getByText(todo)).toBeInTheDocument();
       }
@@ -86,7 +86,7 @@ describe("todo 테스트", () => {
     fireEvent.click(deleteButton);
 
     const deletedTodo = screen.queryByText("일찍 잠자기");
-    expect(deletedTodo).toBeNull;
+    void expect(deletedTodo).toBeNull;
 
     /** All, To do, done 탭 작동 확인하기 */
     const AllTab = screen.getByText("All");


### PR DESCRIPTION
### eslint 경고 수정

- 사용하지 않는 import, event 제거
- 단독으로 실행되는 표현식처럼 보이는 구문들을 "void"로 eslint에게 평가하지 않도록 명시